### PR TITLE
OPENPASS-2337 - Note to author visible only in edit mode

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,9 +1,11 @@
+<!--
 ## Note to author:
 * Please fill in this template fully for every PR.
 * For FE features, it is a requirement to include screenshots and/or videos of the feature working. Videos are preferred. However, all changes will benefit from screenshots of testing evidence.
 * Ensure the size and complexity of your PR is as small as possible. This will help the reviewer give a good review.
 * Choose your reviewer wisely - they should be SMEs in the area of change. Multiple reviewers for complex changes are encouraged.
 * The reviewer is responsible for the functionality of this PR working correctly just as much as the author. It is encouraged for the reviewer to check out the change and test according to the test plan.
+-->
 
 ## JIRA Ticket
 


### PR DESCRIPTION
## JIRA Ticket

https://atlassian.thetradedesk.com/jira/browse/OPENPASS-2337

## What does this PR solve?

Note to author will be visible to author when creating the PR, but not in the PR itself after creation

## Where should the reviewer start?

N/A

## Test plan

N/A

## Screenshots / Videos

N/A
